### PR TITLE
Pass options for TaskCanvasTabs

### DIFF
--- a/src/taskCanvasTabs/TaskCanvasTabsList.js
+++ b/src/taskCanvasTabs/TaskCanvasTabsList.js
@@ -10,6 +10,9 @@ const taskCanvasTabsList = [
     id: 'taskCanvasTabVerify',
     icon: <VerifiedUserIcon />,
     component: VerifyTab,
+    options: {
+      if: (props) => props.task.attributes.direction !== 'outbound',
+    },
   },
   {
     label: 'Video',

--- a/src/taskCanvasTabs/index.js
+++ b/src/taskCanvasTabs/index.js
@@ -15,7 +15,8 @@ function addTaskCanvasTabs(flex, accountSid, customerData) {
         key={tab.id}
       >
         <TabContentComponent key={tab.id} data={customerData} />
-      </Tab>
+      </Tab>,
+      tab.options
     );
   }
 }


### PR DESCRIPTION
Verify tab includes if: expression to prevent it loading on outbound calls. VerifyTab.js accesses `task.attributes.worker` and tries to do a split on it. This attribute does not exist on outbound dialpad calls so it was preventing Flex UI from loading on outbound dialpad calls.

This PR adds a conditional expression that will not load the Verify tab for outbound dialpad calls. 